### PR TITLE
Update ionicons to v5.2.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 > Use Ionicons in Sass as inline SVG, no images or webfonts needed
 
-ionicons-inline lets you use [Ionicons] in your CSS without images or webfonts. It embeds the icons as embedded SVG's via data URI's. This is based on ionicons v4.3.0.
+ionicons-inline lets you use [Ionicons] in your CSS without images or webfonts. It embeds the icons as embedded SVG's via data URI's. This is based on ionicons v5.2.3.
 
 [ionicons]: https://ionicons.com/
 
@@ -13,7 +13,7 @@ ionicons-inline lets you use [Ionicons] in your CSS without images or webfonts. 
 ```scss
 button::before {
   content: '';
-  @include ion-md-wifi(16px, #aaddff);
+  @include ion-add-outline(16px, #aaddff);
 }
 ```
 
@@ -60,7 +60,7 @@ Just use a mixin named `ion-<iconname>`. See [Ionic framework icons](https://ion
 
 ```scss
 .icon {
-  @include ion-md-wifi(16px, #aaddff);
+  @include ion-add-outline(16px, #aaddff);
 }
 ```
 
@@ -70,7 +70,7 @@ This sets many properties (width, height, background-image, background-size, bac
 
 ```scss
 .icon {
-  background-image: ion-md-wifi-image(16px, #aaddff);
+  background-image: ion-add-outline-image(16px, #aaddff);
 }
 ```
 

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "devDependencies": {
     "dedent": "0.7.0",
     "glob": "7.1.2",
-    "ionicons": "4.3.0",
+    "ionicons": "5.2.3",
     "jest": "23.5.0",
     "meow": "5.0.0",
     "node-sass": "4.9.3"

--- a/test/test.js
+++ b/test/test.js
@@ -30,6 +30,6 @@ it('works', () => {
 
 it('has an output', () => {
   const scss = readFileSync('dist/ionicons.scss', 'utf-8')
-  expect(scss).toContain('ion-ios-add')
+  expect(scss).toContain('ion-add-outline')
   expect(scss).toContain('data:image/svg+xml;charset=utf-8,')
 })

--- a/yarn.lock
+++ b/yarn.lock
@@ -1413,9 +1413,10 @@ invert-kv@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/invert-kv/-/invert-kv-1.0.0.tgz#104a8e4aaca6d3d8cd157a8ef8bfab2d7a3ffdb6"
 
-ionicons@4.3.0:
-  version "4.3.0"
-  resolved "https://registry.yarnpkg.com/ionicons/-/ionicons-4.3.0.tgz#89a7060e6bde412275a7083a029e010b66da897d"
+ionicons@5.2.3:
+  version "5.2.3"
+  resolved "https://registry.yarnpkg.com/ionicons/-/ionicons-5.2.3.tgz#af4018ea7585b1e9ae11757731c77f2f36e0c7ac"
+  integrity sha512-87qtgBkieKVFagwYA9Cf91B3PCahQbEOMwMt8bSvlQSgflZ4eE5qI4MGj2ZlIyadeX0dgo+0CzZsy3ow0CsBAg==
 
 is-accessor-descriptor@^0.1.6:
   version "0.1.6"


### PR DESCRIPTION
hello 👋 

a small PR to fix #2 
 
- [x] Update ionicons to v5.2.3
- [x] Update tests - notice that icon `ion-ios-add` is not present on v5.2.3 (I assume it was removed on latest/prior version/s)
- [x] Update ionicon version and sample icon on README

I think this should be released as v2.0.0 since some icons on ionicons are removed (such as `ios-add` and `md-wifi`)